### PR TITLE
Update pack.go

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -79,7 +79,7 @@ func pack(b *[]byte, v interface{}) error {
 		return nil
 	case reflect.String:
 		bstr := []byte(v.(string))
-		l := len(bstr)
+		l := int64(len(bstr))
 		switch {
 		case l < 0x64:
 			*b = append(*b, uint8(0x80+l))


### PR DESCRIPTION
When installing [go-qpack](https://github.com/transceptor-technology/go-qpack/) with the `$ go get github.com/transceptor-technology/go-qpack` on a Raspberry Pi (32bit ARM) it gives the following error
```
go/src/github.com/transceptor-technology/go-qpack/pack.go:94: constant 4294967296 overflows int
go/src/github.com/transceptor-technology/go-qpack/pack.go:99: constant 9223372036854775807 overflows int
```
After looking at the code, you do a `l := len(bstr)` at [line 84](https://github.com/transceptor-technology/go-qpack/blob/master/pack.go#L82) which returns an `int`, however according to the [documentation](https://golang.org/pkg/builtin/#int), an `int` is only guaranteed to be at least 32 bits, which is a problem when attempting to build and compile it on 32bit architecture, as you test for more than 32 bits. A possible fix is therefore to cast the `len(bstr)` to a `int64`, which makes the code run on both the Raspberry Pi and my Laptop (64bit Ubuntu).

However, I am not that confident in Go, so I am not sure if this has any other unwanted side effects.